### PR TITLE
Add linux url for saml2aws

### DIFF
--- a/saml2aws.rb
+++ b/saml2aws.rb
@@ -2,9 +2,14 @@ require 'formula'
 
 class Saml2aws < Formula
   homepage 'https://github.com/versent/saml2aws'
-  url 'https://github.com/Versent/saml2aws/releases/download/v2.12.0/saml2aws_2.12.0_darwin_amd64.tar.gz'
   version '2.12.0'
-  sha256 '19061c92f1673586a20d192be2295ea5a78902ef18ded2feaa2ca1fd117e3664'
+  if OS.mac?
+    url 'https://github.com/Versent/saml2aws/releases/download/v2.12.0/saml2aws_2.12.0_darwin_amd64.tar.gz'
+    sha256 '19061c92f1673586a20d192be2295ea5a78902ef18ded2feaa2ca1fd117e3664'
+  elsif OS.linux?
+    url 'https://github.com/Versent/saml2aws/releases/download/v2.12.0/saml2aws_2.12.0_linux_amd64.tar.gz'
+    sha256 '43f904b8ecb3b7e6c6cb110870f0ddcc4311e628dadfe2ba37788385828662c5'
+  end
 
   depends_on :arch => :x86_64
 

--- a/saml2aws.rb
+++ b/saml2aws.rb
@@ -2,13 +2,13 @@ require 'formula'
 
 class Saml2aws < Formula
   homepage 'https://github.com/versent/saml2aws'
-  version '2.12.0'
+  version '2.13.0'
   if OS.mac?
-    url 'https://github.com/Versent/saml2aws/releases/download/v2.12.0/saml2aws_2.12.0_darwin_amd64.tar.gz'
-    sha256 '19061c92f1673586a20d192be2295ea5a78902ef18ded2feaa2ca1fd117e3664'
+    url 'https://github.com/Versent/saml2aws/releases/download/v2.13.0/saml2aws_2.13.0_darwin_amd64.tar.gz'
+    sha256 '3872dde486254daf572630d5d22eeae59511189b9d84dfa7deab760ec4632dbb'
   elsif OS.linux?
-    url 'https://github.com/Versent/saml2aws/releases/download/v2.12.0/saml2aws_2.12.0_linux_amd64.tar.gz'
-    sha256 '43f904b8ecb3b7e6c6cb110870f0ddcc4311e628dadfe2ba37788385828662c5'
+    url 'https://github.com/Versent/saml2aws/releases/download/v2.13.0/saml2aws_2.13.0_linux_amd64.tar.gz'
+    sha256 'bcd84fcf2af54630688e00884e7bf9850dc6e26d7c278f39eccfba05ab64d12f'
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
Even when saml2aws release is available for Linux machines. It is impossible to install it using linuxbrew. By default, it installs darwin version which does not work. With this small change it will be possible from now. 