### PR TITLE
Bump saml2aws to v2.27.0

### DIFF
--- a/saml2aws.rb
+++ b/saml2aws.rb
@@ -2,13 +2,13 @@ require 'formula'
 
 class Saml2aws < Formula
   homepage 'https://github.com/versent/saml2aws'
-  version '2.26.2'
+  version '2.27.0'
   if OS.mac?
-    url 'https://github.com/Versent/saml2aws/releases/download/v2.26.2/saml2aws_2.26.2_darwin_amd64.tar.gz'
-    sha256 'f8ddb6b2f954af0e8ef16425220f6f7aded18bd58148d7e233927df9764ec3af'
+    url "https://github.com/Versent/saml2aws/releases/download/v#{version}/saml2aws_#{version}_darwin_amd64.tar.gz"
+    sha256 '8002b745a5066faf24e8143f4e56005a6f866db43e9e62a1ebdbb805bccffe29'
   elsif OS.linux?
-    url 'https://github.com/Versent/saml2aws/releases/download/v2.26.2/saml2aws_2.26.2_linux_amd64.tar.gz'
-    sha256 'd0f719fce1ba53a8e9f429fa62ed41a110f5db336a65aa001d9b475914dbd9c9'
+    url "https://github.com/Versent/saml2aws/releases/download/v#{version}/saml2aws_#{version}_linux_amd64.tar.gz"
+    sha256 'b63b1566d2b5bfed2c4c2b912b4a3394ea1859ab40b6c52a5cf3c475fb1315f9'
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
Updates saml2aws version

`λ shasum -a 256 saml2aws_2.27.0_darwin_amd64.tar.gz
8002b745a5066faf24e8143f4e56005a6f866db43e9e62a1ebdbb805bccffe29  saml2aws_2.27.0_darwin_amd64.tar.gz`

`λ shasum -a 256 saml2aws_2.27.0_linux_amd64.tar.gz
b63b1566d2b5bfed2c4c2b912b4a3394ea1859ab40b6c52a5cf3c475fb1315f9  saml2aws_2.27.0_linux_amd64.tar.gz
`