### PR TITLE
Bump saml2aws to v2.27.1

### DIFF
--- a/saml2aws.rb
+++ b/saml2aws.rb
@@ -2,13 +2,13 @@ require 'formula'
 
 class Saml2aws < Formula
   homepage 'https://github.com/versent/saml2aws'
-  version '2.27.0'
+  version '2.27.1'
   if OS.mac?
     url "https://github.com/Versent/saml2aws/releases/download/v#{version}/saml2aws_#{version}_darwin_amd64.tar.gz"
-    sha256 '8002b745a5066faf24e8143f4e56005a6f866db43e9e62a1ebdbb805bccffe29'
+    sha256 'a71477db0bf8d26d2b7fa2d656c280906959863901f4361e6f92a3dab2e8c06d'
   elsif OS.linux?
     url "https://github.com/Versent/saml2aws/releases/download/v#{version}/saml2aws_#{version}_linux_amd64.tar.gz"
-    sha256 'b63b1566d2b5bfed2c4c2b912b4a3394ea1859ab40b6c52a5cf3c475fb1315f9'
+    sha256 'd4a58665b712a737e60215c2fb48a5dc18d9f7c35154babece7e4c5ab4574150'
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
Checksums of files downloaded today from Github releases.

```text
$ sha256sum ~/Descargas/*saml2aws*
a71477db0bf8d26d2b7fa2d656c280906959863901f4361e6f92a3dab2e8c06d  /home/isme/Descargas/saml2aws_2.27.1_darwin_amd64.tar.gz
d4a58665b712a737e60215c2fb48a5dc18d9f7c35154babece7e4c5ab4574150  /home/isme/Descargas/saml2aws_2.27.1_linux_amd64.tar.gz
```
