### PR TITLE
Migrate saml2aws to homebrew/core

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,0 +1,3 @@
+{
+  "saml2aws": "homebrew/core"
+}


### PR DESCRIPTION
This will automatically migrate installations to the new homebrew/core formula for existing users.